### PR TITLE
implement timing-based paste detection for multi-line input

### DIFF
--- a/PASTE_DETECTION.md
+++ b/PASTE_DETECTION.md
@@ -1,0 +1,61 @@
+# Paste Detection Feature
+
+This document describes the paste detection functionality implemented in SecretShare to handle multi-line secrets and keys that contain newline characters.
+
+## Problem
+
+Previously, when pasting secrets or keys that contained newline characters, the input would be terminated at the first newline, truncating the content. This was problematic for:
+- Multi-line certificates
+- Base64 encoded content with line breaks
+- Secrets that naturally contain newlines
+
+## Solution
+
+A timing-based approach is used to distinguish between:
+1. **Manual Enter**: User manually presses Enter (≥15ms gap from previous character) → Terminates input
+2. **Pasted Enter**: Newline character in pasted content (<15ms gap from previous character) → Preserved as part of input
+
+## Implementation Details
+
+### Timing Threshold
+- **15 milliseconds** is used as the threshold
+- Manual typing typically has 100-200ms+ gaps between characters
+- Paste operations typically have <1ms gaps between characters
+- 15ms provides a safe buffer for various typing speeds and system performance
+
+### Functions Modified
+- `PromptUser()`: Now uses `readInputWithPasteDetection()`
+- `PromptSecret()`: Now uses `readSecretWithPasteDetection()`
+
+### Features
+- Character echoing for regular input (masked with `*` for secrets)
+- Backspace support
+- Ctrl+C handling (treated as quit)
+- Fallback to original behavior if terminal raw mode fails
+
+### Character Handling
+- Printable characters (ASCII 32+) and tabs are accepted
+- Newlines (`\n`) and carriage returns (`\r`) are handled based on timing
+- Backspace (127, 8) removes last character
+- Ctrl+C (3) terminates with quit signal
+
+## Testing
+
+To test the functionality:
+
+1. **Manual typing test**:
+   - Type text character by character
+   - Press Enter manually
+   - Should terminate input
+
+2. **Paste test**:
+   - Copy multi-line text to clipboard
+   - Paste into the prompt
+   - Should preserve all newlines as part of the input
+
+## Backward Compatibility
+
+The implementation maintains backward compatibility:
+- Single-line input continues to work as before
+- Manual Enter still terminates input
+- Fallback to original behavior if raw terminal mode is unavailable

--- a/test_paste_detection.sh
+++ b/test_paste_detection.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Test script to verify paste detection functionality
+# This script creates test scenarios to verify that:
+# 1. Manual Enter terminates input
+# 2. Pasted content with newlines is preserved
+
+echo "Testing paste detection functionality..."
+echo ""
+echo "Manual test required - this functionality needs interactive testing."
+echo "To test:"
+echo "1. Run: ./secret_share"
+echo "2. Choose sender mode (s)"
+echo "3. When prompted for receiver's public key, test both:"
+echo "   a) Type some text and press Enter manually (should terminate)"
+echo "   b) Paste multi-line text (should preserve newlines)"
+echo "4. When prompted for secret, test both:"
+echo "   a) Type a secret and press Enter manually (should terminate)"
+echo "   b) Paste a multi-line secret (should preserve newlines)"
+echo ""
+echo "Expected behavior:"
+echo "- Manual typing + Enter: Input terminates"
+echo "- Paste with newlines: Newlines preserved as part of input"
+echo "- Time gap threshold: 15ms"

--- a/tui/interface.go
+++ b/tui/interface.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/term"
 )
@@ -49,9 +50,77 @@ func infoText(text string) string {
 func PromptUser(prompt string) string {
 	fmt.Println()
 	fmt.Print(promptText(prompt))
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	return scanner.Text()
+	return readInputWithPasteDetection()
+}
+
+// readInputWithPasteDetection reads user input, detecting pasted content
+// by measuring time between characters. Manual Enter (>=15ms gap) ends input,
+// while pasted Enter (<15ms gap) is treated as part of the content.
+func readInputWithPasteDetection() string {
+	// Put terminal in raw mode to read characters individually
+	oldState, err := term.MakeRaw(int(syscall.Stdin))
+	if err != nil {
+		// Fallback to line-based input
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		return scanner.Text()
+	}
+	defer term.Restore(int(syscall.Stdin), oldState)
+
+	var result strings.Builder
+	buf := make([]byte, 1)
+	lastCharTime := time.Now()
+	firstChar := true
+
+	for {
+		_, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+
+		currentTime := time.Now()
+		ch := buf[0]
+
+		// Handle newline/carriage return
+		if ch == '\n' || ch == '\r' {
+			if !firstChar {
+				// Check timing: if >=15ms since last char, treat as manual Enter
+				gap := currentTime.Sub(lastCharTime)
+				if gap >= 15*time.Millisecond {
+					fmt.Println() // Echo the newline
+					break         // End of input
+				}
+			}
+			// Otherwise, treat as part of pasted content
+			result.WriteByte('\n')
+			fmt.Println() // Echo the newline
+		} else if ch == 127 || ch == 8 { // Backspace or DEL
+			// Handle backspace
+			if result.Len() > 0 {
+				// Remove last character from result
+				str := result.String()
+				if len(str) > 0 {
+					result.Reset()
+					result.WriteString(str[:len(str)-1])
+				}
+				// Echo backspace
+				fmt.Print("\b \b")
+			}
+		} else if ch >= 32 || ch == '\t' { // Printable characters and tab
+			result.WriteByte(ch)
+			fmt.Print(string(ch)) // Echo the character
+		}
+		// Handle Ctrl+C (ETX)
+		if ch == 3 {
+			fmt.Println()
+			return "q" // Treat as quit
+		}
+
+		lastCharTime = currentTime
+		firstChar = false
+	}
+
+	return result.String()
 }
 
 // PromptSecret displays a prompt and waits for user input, masking the characters
@@ -59,16 +128,80 @@ func PromptUser(prompt string) string {
 func PromptSecret(prompt string) string {
 	fmt.Println()
 	fmt.Print(promptText(prompt))
+	return readSecretWithPasteDetection()
+}
 
-	// Read password (masked input)
-	bytes, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println() // Add a newline after the masked input
-
+// readSecretWithPasteDetection reads secret input with masking, detecting pasted content
+// by measuring time between characters. Manual Enter (>=15ms gap) ends input,
+// while pasted Enter (<15ms gap) is treated as part of the content.
+func readSecretWithPasteDetection() string {
+	// Put terminal in raw mode to read characters individually
+	oldState, err := term.MakeRaw(int(syscall.Stdin))
 	if err != nil {
-		return ""
+		// Fallback to standard masked input
+		bytes, err := term.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+		if err != nil {
+			return ""
+		}
+		return string(bytes)
+	}
+	defer term.Restore(int(syscall.Stdin), oldState)
+
+	var result strings.Builder
+	buf := make([]byte, 1)
+	lastCharTime := time.Now()
+	firstChar := true
+
+	for {
+		_, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+
+		currentTime := time.Now()
+		ch := buf[0]
+
+		// Handle newline/carriage return
+		if ch == '\n' || ch == '\r' {
+			if !firstChar {
+				// Check timing: if >=15ms since last char, treat as manual Enter
+				gap := currentTime.Sub(lastCharTime)
+				if gap >= 15*time.Millisecond {
+					fmt.Println() // Echo the newline
+					break         // End of input
+				}
+			}
+			// Otherwise, treat as part of pasted content
+			result.WriteByte('\n')
+			fmt.Println() // Echo the newline (but don't show the actual character)
+		} else if ch == 127 || ch == 8 { // Backspace or DEL
+			// Handle backspace
+			if result.Len() > 0 {
+				// Remove last character from result
+				str := result.String()
+				if len(str) > 0 {
+					result.Reset()
+					result.WriteString(str[:len(str)-1])
+				}
+				// Echo backspace
+				fmt.Print("\b \b")
+			}
+		} else if ch >= 32 || ch == '\t' { // Printable characters and tab
+			result.WriteByte(ch)
+			fmt.Print("*") // Mask with asterisk
+		}
+		// Handle Ctrl+C (ETX)
+		if ch == 3 {
+			fmt.Println()
+			return "q" // Treat as quit
+		}
+
+		lastCharTime = currentTime
+		firstChar = false
 	}
 
-	return string(bytes)
+	return result.String()
 }
 
 // PromptUserSingleChar displays a prompt and waits for a single character input


### PR DESCRIPTION
- Add timing-based detection to distinguish manual Enter from pasted newlines
- Manual Enter (≥15ms gap) terminates input, pasted Enter (<15ms) preserved
- Update PromptUser and PromptSecret to use new paste detection
- Maintain character masking for secrets with asterisks
- Support backspace, Ctrl+C, and fallback for terminal issues
- Preserve backward compatibility for single-line input
- Add documentation and test guidance


Change-ID: sc882e6b2736d3af2k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced input handling: preserves pasted multi-line content while Enter submits typed input. Supports backspace editing and Ctrl+C to quit. Secret entry is masked and supports multi-line paste.
  - Backward compatible: single-line typing and Enter-to-submit remain unchanged.

- Documentation
  - Added a guide explaining paste-detection behavior, usage, testing steps, and compatibility notes.

- Tests
  - Added a manual testing script/instructions to verify paste vs typed input behavior in the secret sharing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->