### PR TITLE
implement timing-based paste detection for multi-line input

### DIFF
--- a/tui/interface.go
+++ b/tui/interface.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/term"
 )
@@ -49,9 +50,77 @@ func infoText(text string) string {
 func PromptUser(prompt string) string {
 	fmt.Println()
 	fmt.Print(promptText(prompt))
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	return scanner.Text()
+	return readInputWithPasteDetection()
+}
+
+// readInputWithPasteDetection reads user input, detecting pasted content
+// by measuring time between characters. Manual Enter (>=15ms gap) ends input,
+// while pasted Enter (<15ms gap) is treated as part of the content.
+func readInputWithPasteDetection() string {
+	// Put terminal in raw mode to read characters individually
+	oldState, err := term.MakeRaw(int(syscall.Stdin))
+	if err != nil {
+		// Fallback to line-based input
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		return scanner.Text()
+	}
+	defer term.Restore(int(syscall.Stdin), oldState)
+
+	var result strings.Builder
+	buf := make([]byte, 1)
+	lastCharTime := time.Now()
+	firstChar := true
+
+	for {
+		_, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+
+		currentTime := time.Now()
+		ch := buf[0]
+
+		// Handle newline/carriage return
+		if ch == '\n' || ch == '\r' {
+			if !firstChar {
+				// Check timing: if >=15ms since last char, treat as manual Enter
+				gap := currentTime.Sub(lastCharTime)
+				if gap >= 15*time.Millisecond {
+					fmt.Println() // Echo the newline
+					break         // End of input
+				}
+			}
+			// Otherwise, treat as part of pasted content
+			result.WriteByte('\n')
+			fmt.Println() // Echo the newline
+		} else if ch == 127 || ch == 8 { // Backspace or DEL
+			// Handle backspace
+			if result.Len() > 0 {
+				// Remove last character from result
+				str := result.String()
+				if len(str) > 0 {
+					result.Reset()
+					result.WriteString(str[:len(str)-1])
+				}
+				// Echo backspace
+				fmt.Print("\b \b")
+			}
+		} else if ch >= 32 || ch == '\t' { // Printable characters and tab
+			result.WriteByte(ch)
+			fmt.Print(string(ch)) // Echo the character
+		}
+		// Handle Ctrl+C (ETX)
+		if ch == 3 {
+			fmt.Println()
+			return "q" // Treat as quit
+		}
+
+		lastCharTime = currentTime
+		firstChar = false
+	}
+
+	return result.String()
 }
 
 // PromptSecret displays a prompt and waits for user input, masking the characters
@@ -59,16 +128,80 @@ func PromptUser(prompt string) string {
 func PromptSecret(prompt string) string {
 	fmt.Println()
 	fmt.Print(promptText(prompt))
+	return readSecretWithPasteDetection()
+}
 
-	// Read password (masked input)
-	bytes, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println() // Add a newline after the masked input
-
+// readSecretWithPasteDetection reads secret input with masking, detecting pasted content
+// by measuring time between characters. Manual Enter (>=15ms gap) ends input,
+// while pasted Enter (<15ms gap) is treated as part of the content.
+func readSecretWithPasteDetection() string {
+	// Put terminal in raw mode to read characters individually
+	oldState, err := term.MakeRaw(int(syscall.Stdin))
 	if err != nil {
-		return ""
+		// Fallback to standard masked input
+		bytes, err := term.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+		if err != nil {
+			return ""
+		}
+		return string(bytes)
+	}
+	defer term.Restore(int(syscall.Stdin), oldState)
+
+	var result strings.Builder
+	buf := make([]byte, 1)
+	lastCharTime := time.Now()
+	firstChar := true
+
+	for {
+		_, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+
+		currentTime := time.Now()
+		ch := buf[0]
+
+		// Handle newline/carriage return
+		if ch == '\n' || ch == '\r' {
+			if !firstChar {
+				// Check timing: if >=15ms since last char, treat as manual Enter
+				gap := currentTime.Sub(lastCharTime)
+				if gap >= 15*time.Millisecond {
+					fmt.Println() // Echo the newline
+					break         // End of input
+				}
+			}
+			// Otherwise, treat as part of pasted content
+			result.WriteByte('\n')
+			fmt.Println() // Echo the newline (but don't show the actual character)
+		} else if ch == 127 || ch == 8 { // Backspace or DEL
+			// Handle backspace
+			if result.Len() > 0 {
+				// Remove last character from result
+				str := result.String()
+				if len(str) > 0 {
+					result.Reset()
+					result.WriteString(str[:len(str)-1])
+				}
+				// Echo backspace
+				fmt.Print("\b \b")
+			}
+		} else if ch >= 32 || ch == '\t' { // Printable characters and tab
+			result.WriteByte(ch)
+			fmt.Print("*") // Mask with asterisk
+		}
+		// Handle Ctrl+C (ETX)
+		if ch == 3 {
+			fmt.Println()
+			return "q" // Treat as quit
+		}
+
+		lastCharTime = currentTime
+		firstChar = false
 	}
 
-	return string(bytes)
+	return result.String()
 }
 
 // PromptUserSingleChar displays a prompt and waits for a single character input

--- a/tui/interface.go
+++ b/tui/interface.go
@@ -95,16 +95,18 @@ func readInputWithPasteDetection() string {
 			result.WriteByte('\n')
 			fmt.Println() // Echo the newline
 		} else if ch == 127 || ch == 8 { // Backspace or DEL
-			// Handle backspace
-			if result.Len() > 0 {
-				// Remove last character from result
-				str := result.String()
-				if len(str) > 0 {
+			// Handle backspace - remove last rune, not byte
+			str := result.String()
+			if len(str) > 0 {
+				// Convert to runes to properly handle multi-byte UTF-8 characters
+				runes := []rune(str)
+				if len(runes) > 0 {
+					// Remove last rune and rebuild string
 					result.Reset()
-					result.WriteString(str[:len(str)-1])
+					result.WriteString(string(runes[:len(runes)-1]))
+					// Echo backspace
+					fmt.Print("\b \b")
 				}
-				// Echo backspace
-				fmt.Print("\b \b")
 			}
 		} else if ch >= 32 || ch == '\t' { // Printable characters and tab
 			result.WriteByte(ch)
@@ -176,16 +178,18 @@ func readSecretWithPasteDetection() string {
 			result.WriteByte('\n')
 			fmt.Println() // Echo the newline (but don't show the actual character)
 		} else if ch == 127 || ch == 8 { // Backspace or DEL
-			// Handle backspace
-			if result.Len() > 0 {
-				// Remove last character from result
-				str := result.String()
-				if len(str) > 0 {
+			// Handle backspace - remove last rune, not byte
+			str := result.String()
+			if len(str) > 0 {
+				// Convert to runes to properly handle multi-byte UTF-8 characters
+				runes := []rune(str)
+				if len(runes) > 0 {
+					// Remove last rune and rebuild string
 					result.Reset()
-					result.WriteString(str[:len(str)-1])
+					result.WriteString(string(runes[:len(runes)-1]))
+					// Echo backspace
+					fmt.Print("\b \b")
 				}
-				// Echo backspace
-				fmt.Print("\b \b")
 			}
 		} else if ch >= 32 || ch == '\t' { // Printable characters and tab
 			result.WriteByte(ch)

--- a/tui/paste_detection_test.go
+++ b/tui/paste_detection_test.go
@@ -1,0 +1,253 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test helper function to simulate timing behavior
+func TestTimingLogic(t *testing.T) {
+	// Test manual typing scenario (>= 15ms gaps)
+	manualGap := 50 * time.Millisecond
+	if manualGap < 15*time.Millisecond {
+		t.Errorf("Manual gap %v should be >= 15ms", manualGap)
+	}
+
+	// Test paste scenario (< 15ms gaps)
+	pasteGap := 5 * time.Millisecond
+	if pasteGap >= 15*time.Millisecond {
+		t.Errorf("Paste gap %v should be < 15ms", pasteGap)
+	}
+}
+
+// Test UTF-8 rune handling in backspace logic
+func TestRuneHandling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ASCII characters",
+			input:    "hello",
+			expected: "hell",
+		},
+		{
+			name:     "UTF-8 emoji",
+			input:    "hello🔒",
+			expected: "hello",
+		},
+		{
+			name:     "UTF-8 accented characters",
+			input:    "café",
+			expected: "caf",
+		},
+		{
+			name:     "Mixed UTF-8",
+			input:    "test🔑password",
+			expected: "test🔑passwor",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Single rune",
+			input:    "a",
+			expected: "",
+		},
+		{
+			name:     "Single emoji",
+			input:    "🔒",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the backspace logic from our functions
+			str := tt.input
+			if len(str) > 0 {
+				runes := []rune(str)
+				if len(runes) > 0 {
+					result := string(runes[:len(runes)-1])
+					if result != tt.expected {
+						t.Errorf("Expected %q, got %q", tt.expected, result)
+					}
+				}
+			} else if tt.expected != "" {
+				t.Errorf("Expected %q for empty input, got empty string", tt.expected)
+			}
+		})
+	}
+}
+
+// Test character classification logic
+func TestCharacterClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		ch       byte
+		expected string // "printable", "newline", "backspace", "ctrl-c", "other"
+	}{
+		{"Space", 32, "printable"},
+		{"Letter A", 65, "printable"},
+		{"Tab", 9, "printable"},
+		{"Newline", 10, "newline"},
+		{"Carriage Return", 13, "newline"},
+		{"Backspace", 8, "backspace"},
+		{"DEL", 127, "backspace"},
+		{"Ctrl+C", 3, "ctrl-c"},
+		{"Non-printable", 1, "other"},
+		{"Non-printable high", 31, "other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actual string
+			ch := tt.ch
+
+			// Replicate the character classification logic from our functions
+			if ch == '\n' || ch == '\r' {
+				actual = "newline"
+			} else if ch == 127 || ch == 8 {
+				actual = "backspace"
+			} else if ch >= 32 || ch == '\t' {
+				actual = "printable"
+			} else if ch == 3 {
+				actual = "ctrl-c"
+			} else {
+				actual = "other"
+			}
+
+			if actual != tt.expected {
+				t.Errorf("Character %d (%c): expected %s, got %s", ch, ch, tt.expected, actual)
+			}
+		})
+	}
+}
+
+// Test newline handling in multiline content
+func TestNewlineHandling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Single line",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "Two lines with LF",
+			input:    "line1\nline2",
+			expected: "line1\nline2",
+		},
+		{
+			name:     "Two lines with CRLF",
+			input:    "line1\r\nline2",
+			expected: "line1\n\nline2", // Both \r and \n become \n
+		},
+		{
+			name:     "Multiple lines",
+			input:    "line1\nline2\nline3",
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "Empty lines",
+			input:    "line1\n\nline3",
+			expected: "line1\n\nline3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate processing each character like our paste detection does
+			var result strings.Builder
+			for _, ch := range []byte(tt.input) {
+				if ch == '\n' || ch == '\r' {
+					result.WriteByte('\n') // Normalize all newlines to \n
+				} else if ch >= 32 || ch == '\t' {
+					result.WriteByte(ch)
+				}
+			}
+
+			if result.String() != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result.String())
+			}
+		})
+	}
+}
+
+// Test edge cases
+func TestEdgeCases(t *testing.T) {
+	// Test timing threshold boundary
+	threshold := 15 * time.Millisecond
+	boundaryTests := []struct {
+		name           string
+		gap            time.Duration
+		expectedManual bool
+	}{
+		{"Just under threshold", 14 * time.Millisecond, false},
+		{"Exactly at threshold", 15 * time.Millisecond, true},
+		{"Just over threshold", 16 * time.Millisecond, true},
+		{"Way over threshold", 100 * time.Millisecond, true},
+	}
+
+	for _, tt := range boundaryTests {
+		t.Run(tt.name, func(t *testing.T) {
+			isManual := tt.gap >= threshold
+			if isManual != tt.expectedManual {
+				t.Errorf("Gap %v: expected manual=%v, got %v", tt.gap, tt.expectedManual, isManual)
+			}
+		})
+	}
+}
+
+// Test string builder behavior with our usage patterns
+func TestStringBuilderBehavior(t *testing.T) {
+	tests := []struct {
+		name       string
+		operations []string // "write:text", "reset", "writeByte:X"
+		expected   string
+	}{
+		{
+			name:       "Basic write and reset",
+			operations: []string{"write:hello", "reset", "write:world"},
+			expected:   "world",
+		},
+		{
+			name:       "WriteByte operations",
+			operations: []string{"writeByte:a", "writeByte:b", "writeByte:c"},
+			expected:   "abc",
+		},
+		{
+			name:       "Mixed operations",
+			operations: []string{"write:test", "writeByte:X", "reset", "writeByte:Y"},
+			expected:   "Y",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var builder strings.Builder
+			for _, op := range tt.operations {
+				parts := strings.Split(op, ":")
+				switch parts[0] {
+				case "write":
+					builder.WriteString(parts[1])
+				case "writeByte":
+					builder.WriteByte(parts[1][0])
+				case "reset":
+					builder.Reset()
+				}
+			}
+
+			if builder.String() != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, builder.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add timing-based detection to distinguish manual Enter from pasted newlines
- Manual Enter (≥15ms gap) terminates input, pasted Enter (<15ms) preserved
- Update PromptUser and PromptSecret to use new paste detection
- Maintain character masking for secrets with asterisks
- Support backspace, Ctrl+C, and fallback for terminal issues
- Preserve backward compatibility for single-line input


Change-ID: saad384a779072440k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Text input now detects pasted content to prevent accidental submission on paste.
  * Secret input is masked with “*” and benefits from the same paste-detection behavior.
  * Responsive editing with backspace support during entry and consistent cancel/quit keys.
  * Automatic fallback for terminals lacking advanced input support.

* **Tests**
  * Added comprehensive unit tests covering paste-detection, backspace across character types, newline normalization, and timing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->